### PR TITLE
added 'vrc_copy_command' setting to copy current curl command to vim register

### DIFF
--- a/doc/vim-rest-console.txt
+++ b/doc/vim-rest-console.txt
@@ -40,6 +40,7 @@ CONTENTS                                                         *VrcContents*
       vrc_response_default_content_type.. |vrc_response_default_content_type|
       vrc_set_default_mapping...................... |vrc_set_default_mapping|
       vrc_show_command.....................................|vrc_show_command|
+      vrc_copy_command.....................................|vrc_copy_command|
       vrc_split_request_body........................ |vrc_split_request_body|
       vrc_syntax_highlight_response...........|vrc_syntax_highlight_response|
       vrc_trigger.............................................. |vrc_trigger|
@@ -720,6 +721,14 @@ This option enables the printing of the executed curl command in the output
 pane. It's disabled by default. To enable:
 >
     let g:vrc_show_command = 1
+<
+------------------------------------------------------------------------------
+*vrc_copy_command*
+
+This option enables the copying of the executed curl command to the "+
+register. It's disabled by default. To enable:
+>
+    let g:vrc_copy_command = 1
 <
 ------------------------------------------------------------------------------
 *vrc_split_request_body*

--- a/ftplugin/rest.vim
+++ b/ftplugin/rest.vim
@@ -727,6 +727,7 @@ function! s:RunQuery(start, end)
   " requests using consecutive verbs.
   let resumeFrom = a:start
   let shouldShowCommand = s:GetOpt('vrc_show_command', 0)
+  let shouldCopyCommand = s:GetOpt('vrc_copy_command', 0)
   let shouldDebug = s:GetOpt('vrc_debug', 0)
   while resumeFrom < a:end
     let request = s:ParseRequest(a:start, resumeFrom, a:end, globSection)
@@ -748,6 +749,9 @@ function! s:RunQuery(start, end)
     call add(outputInfo['outputChunks'], output)
     if shouldShowCommand
       call add(outputInfo['commands'], curlCmd)
+    endif
+    if shouldCopyCommand
+      let @+ = curlCmd
     endif
 
     if s:HandleResponse(a:start, resumeFrom, a:end, output, outputInfo) != 0


### PR DESCRIPTION
Add `vrc_copy_command` which acts in similar way to `vrc_show_command` but copies current command to vim's register `"+`